### PR TITLE
Reorder test variables to be consistent with functions.py

### DIFF
--- a/week_5/exercise/tests.ipynb
+++ b/week_5/exercise/tests.ipynb
@@ -149,9 +149,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.testing.assert_almost_equal(arrhenius_equation(24131, 23e10, 300), 14461992.1514407)\n",
+    "np.testing.assert_almost_equal(arrhenius_equation(23e10, 24131, 300), 14461992.1514407)\n",
     "print('Test 1 for Problem 4 Passed!')\n",
-    "np.testing.assert_almost_equal(arrhenius_equation(10, 29, np.array([6, 26, 226])), \n",
+    "np.testing.assert_almost_equal(arrhenius_equation(29, 10, np.array([6, 26, 226])), \n",
     "                               [23.73241504, 27.68905521, 28.8460781])\n",
     "print('Test 2 for Problem 4 Passed!')"
    ]


### PR DESCRIPTION
Asserts fail as order of inputs inconsistent with the order prescribed in the function template.