### PR TITLE
Remove redundant calls to enumerate

### DIFF
--- a/CH40208/python_basics/loops_exercises.ipynb
+++ b/CH40208/python_basics/loops_exercises.ipynb
@@ -77,7 +77,7 @@
     "\n",
     "atoms = [atom_1, atom_2, atom_3]\n",
     "for i, a_i in enumerate(atoms):\n",
-    "    for j, a_j in enumerate(atoms[i+1:]):\n",
+    "    for a_j in atoms[i+1:]:\n",
     "        distances.append(sqrt(sum([(a_i[k] - a_j[k]) ** 2 for k in [0, 1, 2]])))\n",
     "        \n",
     "print(distances)"

--- a/CH40208/working_with_data/numpy_arrays_exercises.ipynb
+++ b/CH40208/working_with_data/numpy_arrays_exercises.ipynb
@@ -100,7 +100,7 @@
     "\n",
     "atoms = np.array([atom_1, atom_2, atom_3])\n",
     "for i, a_i in enumerate(atoms):\n",
-    "    for j, a_j in enumerate(atoms[i+1:]):\n",
+    "    for a_j in atoms[i+1:]:\n",
     "        distances.append(np.sqrt(np.sum((a_i - a_j) ** 2)))\n",
     "        \n",
     "print(distances)"


### PR DESCRIPTION
Just something small I spotted during the in-person workshop last week - some of the worked exercises involving nested loops currently make redundant calls to enumerate (_i.e._ the assigned index variable _j_ is not actually used for anything).