### PR TITLE
Fix axis labels in visualisation2

### DIFF
--- a/CH40208/assets/data/visualisation2.py
+++ b/CH40208/assets/data/visualisation2.py
@@ -16,17 +16,17 @@ def xyz_projections(coords):
     """
     fig, ax = plt.subplots(1,3, sharex=True, sharey=True, 
                            subplot_kw={'aspect':'equal'}, figsize=(12,8))
-    ax[0].set_xlabel('x')
-    ax[0].set_ylabel('y')
-    ax[0].set_title('z')
+    ax[0].set_xlabel('y')
+    ax[0].set_ylabel('z')
+    ax[0].set_title('x')
     
-    ax[1].set_xlabel('z')
-    ax[1].set_ylabel('y')
-    ax[1].set_title('x')
+    ax[1].set_xlabel('x')
+    ax[1].set_ylabel('z')
+    ax[1].set_title('y')
     
-    ax[2].set_xlabel('z')
-    ax[2].set_ylabel('x')
-    ax[2].set_title('y')
+    ax[2].set_xlabel('x')
+    ax[2].set_ylabel('y')
+    ax[2].set_title('z')
     ax[0].plot(coords[:,1], coords[:,2], 'o', markersize=30, clip_on=False)
     ax[1].plot(coords[:,0], coords[:,2], 'o', markersize=30, clip_on=False)
     ax[2].plot(coords[:,0], coords[:,1], 'o', markersize=30, clip_on=False)


### PR DESCRIPTION
The axis labels and titles produced by the `xyz_projections` function in the `visualisation2` module are currently incorrect. 

These labels should now match the coordinates being plotted in each case.